### PR TITLE
Expose port 80/tcp in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ COPY assets/tools/ /usr/bin/
 COPY entrypoint.sh /sbin/entrypoint.sh
 RUN chmod 755 /sbin/entrypoint.sh
 
+EXPOSE 80/tcp
+
 VOLUME ["${OWNCLOUD_DATA_DIR}"]
 
 WORKDIR ${OWNCLOUD_INSTALL_DIR}


### PR DESCRIPTION
I think it is useful to expose port 80/tcp, as the container is able to run an nginx instance bound to this port.

Thank you for your great containers!
